### PR TITLE
Add json1 support

### DIFF
--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/psi/FunctionExprMixin.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/psi/FunctionExprMixin.kt
@@ -1,5 +1,6 @@
 package com.squareup.sqldelight.core.lang.psi
 
+import com.squareup.kotlinpoet.BOOLEAN
 import com.alecstrong.sql.psi.core.DialectPreset
 import com.alecstrong.sql.psi.core.SqlAnnotationHolder
 import com.alecstrong.sql.psi.core.psi.SqlExpr
@@ -71,6 +72,19 @@ internal class FunctionExprMixin(node: ASTNode?) : SqlFunctionExprImpl(node) {
     "nullif" -> exprList[0].type().asNullable()
     "max" -> encapsulatingType(exprList, SqliteType.INTEGER, SqliteType.REAL, SqliteType.TEXT, SqliteType.BLOB).asNullable()
     "min" -> encapsulatingType(exprList, SqliteType.BLOB, SqliteType.TEXT, SqliteType.INTEGER, SqliteType.REAL).asNullable()
+
+    // json1
+
+    "json", "json_remove", "json_extract", "json_insert", "json_replace", "json_set" -> {
+      IntermediateType(SqliteType.TEXT).nullableIf(exprList[0].type().javaType.isNullable)
+    }
+    "json_array", "json_object", "json_group_array", "json_group_object" -> IntermediateType(SqliteType.TEXT)
+    "json_array_length" -> IntermediateType(SqliteType.INTEGER).nullableIf(exprList[0].type().javaType.isNullable)
+    "json_patch" -> IntermediateType(SqliteType.TEXT).nullableIf(exprList.any { it.type().javaType.isNullable })
+    "json_type" -> IntermediateType(SqliteType.TEXT).asNullable()
+    "json_valid" -> IntermediateType(SqliteType.INTEGER, BOOLEAN)
+    "json_quote" -> exprList[0].type().asNonNullable()
+
     else -> when ((containingFile as SqlDelightFile).dialect) {
       DialectPreset.SQLITE_3_18, DialectPreset.SQLITE_3_24, DialectPreset.SQLITE_3_25 -> sqliteFunctionType()
       DialectPreset.MYSQL -> mySqlFunctionType()


### PR DESCRIPTION
An issue exists here on sqldelight main repo for adding support for json1: https://github.com/cashapp/sqldelight/issues/1379

We require json1 for a handful of things in PlanGrid Build, so until this is supported in the main repo we need to continue to add support ourselves.